### PR TITLE
Implement send_broadcast task

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,9 @@ gem "neat"
 gem "nokogiri"
 gem "rack-contrib"
 gem "rake"
+gem "courier", git: "https://github.com/thoughtbot/courier-gem.git"
+
+group :development, :test do
+  gem "rspec"
+  gem "timecop"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/thoughtbot/courier-gem.git
+  revision: cdec6427aed6506f3fbcd33e6412cce78ec16752
+  specs:
+    courier (0.1.0)
+      activesupport (~> 4.2)
+      faraday_middleware (~> 0.8)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -36,8 +44,13 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
+    diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.6.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
     ffi (1.9.10)
     git-version-bump (0.15.1)
     haml (4.0.7)
@@ -88,6 +101,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.8.3)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
@@ -109,6 +123,19 @@ GEM
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     sass (3.4.19)
     sprockets (2.12.4)
       hike (~> 1.2)
@@ -123,6 +150,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -137,12 +165,15 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon
+  courier!
   middleman (~> 3.4)
   middleman-autoprefixer
   neat
   nokogiri
   rack-contrib
   rake
+  rspec
+  timecop
 
 BUNDLED WITH
    1.10.6

--- a/bin/send_broadcast.rb
+++ b/bin/send_broadcast.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+
+require "active_support/time"
+require "logger"
+
+class SendBroadcast
+  Morning = "09:00:00".freeze
+
+  def perform
+    time_zones_where_it_is(Morning).each do |time_zone|
+      logger.info "broadcast to: #{time_zone_identifier(time_zone)}"
+      broadcast(time_zone)
+    end
+  end
+
+  private
+
+  def time_zones_where_it_is(time_string)
+    ActiveSupport::TimeZone.all.select do |tz|
+      time = tz.parse(time_string)
+
+      current_utc_time.between?(
+        time.advance(minutes: -5),
+        time.advance(minutes: 5)
+      )
+    end
+  end
+
+  def broadcast(time_zone)
+    courier.broadcast(time_zone_identifier(time_zone), { content_available: 1 })
+  end
+
+  def time_zone_identifier(time_zone)
+    tzinfo = ActiveSupport::TimeZone.find_tzinfo(time_zone.name)
+    tzinfo.canonical_identifier
+  end
+
+  def logger
+    @logger ||= Logger.new(STDOUT)
+    if ENV["RACK_ENV"] == "test"
+      @logger.level = Logger::FATAL
+    else
+      @logger.level = Logger::DEBUG
+    end
+    @logger
+  end
+
+
+  def courier
+    @courier ||= Courier::Client.new(api_token: ENV["COURIER_API_TOKEN"])
+  end
+
+  def current_utc_time
+    @current_utc_time ||= ActiveSupport::TimeZone.new("UTC").now
+  end
+end

--- a/spec/send_broadcast_spec.rb
+++ b/spec/send_broadcast_spec.rb
@@ -1,0 +1,80 @@
+require "active_support/time"
+require "courier"
+require "timecop"
+require_relative "../bin/send_broadcast"
+
+Timecop.safe_mode = true
+
+RSpec.describe SendBroadcast do
+  describe "#broadcast" do
+    it "broadcasts to time zones where it's currently 9am" do
+      now = ActiveSupport::TimeZone.new("Amsterdam").parse("09:00:00")
+      Timecop.travel(now) do
+        courier = instance_double(Courier::Client)
+        allow(Courier::Client).to receive(:new).and_return(courier)
+        allow(courier).to receive(:broadcast)
+
+        SendBroadcast.new.perform
+
+        expect(courier).to have_received(:broadcast).
+          with("Europe/Amsterdam", { content_available: 1 })
+      end
+    end
+
+    it "broadcasts to time zones where it's currently 09:04:59" do
+      now = ActiveSupport::TimeZone.new("Amsterdam").parse("09:04:59")
+      Timecop.travel(now) do
+        courier = instance_double(Courier::Client)
+        allow(Courier::Client).to receive(:new).and_return(courier)
+        allow(courier).to receive(:broadcast)
+
+        SendBroadcast.new.perform
+
+        expect(courier).to have_received(:broadcast).
+          with("Europe/Amsterdam", { content_available: 1 })
+      end
+    end
+
+    it "does not broadcast to time zones where it's currently 09:05:00" do
+      now = ActiveSupport::TimeZone.new("Amsterdam").parse("09:05:00")
+      Timecop.travel(now) do
+        courier = instance_double(Courier::Client)
+        allow(Courier::Client).to receive(:new).and_return(courier)
+        allow(courier).to receive(:broadcast)
+
+        SendBroadcast.new.perform
+
+        expect(courier).to_not have_received(:broadcast).
+          with("Europe/Amsterdam", { content_available: 1 })
+      end
+    end
+
+    it "broadcasts to time zones where it's currently 8:55:00" do
+      now = ActiveSupport::TimeZone.new("Amsterdam").parse("08:55:00")
+      Timecop.travel(now) do
+        courier = instance_double(Courier::Client)
+        allow(Courier::Client).to receive(:new).and_return(courier)
+        allow(courier).to receive(:broadcast)
+
+        SendBroadcast.new.perform
+
+        expect(courier).to have_received(:broadcast).
+          with("Europe/Amsterdam", { content_available: 1 })
+      end
+    end
+
+    it "does not broadcast to time zones where it's currently 08:49:59" do
+      now = ActiveSupport::TimeZone.new("Amsterdam").parse("08:49:59")
+      Timecop.travel(now) do
+        courier = instance_double(Courier::Client)
+        allow(Courier::Client).to receive(:new).and_return(courier)
+        allow(courier).to receive(:broadcast)
+
+        SendBroadcast.new.perform
+
+        expect(courier).to_not have_received(:broadcast).
+          with("Europe/Amsterdam", { content_available: 1 })
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+ENV["RACK_ENV"] = "test"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.warnings = true
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
If this works, it supersedes #19 

The send_broadcast binary is intended to be called from the Heroku
scheduler add-on every hour. It figures out in which time zones it's
currently 9am and broadcasts to a courier channel with the same name as
the canonical time zone name.

The Tropos app will register on launch with the channel corresponding
with the device's current time zone.

More information here on Heroku's schedulr add-on here.

https://devcenter.heroku.com/articles/scheduler#installing-the-add-on
