### PR TITLE
Use utc offset as courier channel

### DIFF
--- a/spec/send_broadcast_spec.rb
+++ b/spec/send_broadcast_spec.rb
@@ -8,30 +8,42 @@ Timecop.safe_mode = true
 RSpec.describe SendBroadcast do
   describe "#broadcast" do
     it "broadcasts to time zones where it's currently 9am" do
-      now = ActiveSupport::TimeZone.new("Amsterdam").parse("09:00:00")
+      time_zone = ActiveSupport::TimeZone.new("UTC")
+      now = time_zone.parse("09:00:00")
+
       Timecop.travel(now) do
         courier = instance_double(Courier::Client)
         allow(Courier::Client).to receive(:new).and_return(courier)
         allow(courier).to receive(:broadcast)
 
-        SendBroadcast.new.perform
+        send_broadcast = SendBroadcast.new
+        send_broadcast.perform
+
 
         expect(courier).to have_received(:broadcast).
-          with("Europe/Amsterdam", { "content-available": 1 })
+          with(
+            "plus-0000",
+             { "content-available": 1 }
+          ).once
       end
     end
 
     it "broadcasts to time zones where it's currently 09:04:59" do
-      now = ActiveSupport::TimeZone.new("Amsterdam").parse("09:04:59")
+      time_zone = ActiveSupport::TimeZone.new("UTC")
+      now = time_zone.parse("09:04:59")
       Timecop.travel(now) do
         courier = instance_double(Courier::Client)
         allow(Courier::Client).to receive(:new).and_return(courier)
         allow(courier).to receive(:broadcast)
 
-        SendBroadcast.new.perform
+        send_broadcast = SendBroadcast.new
+        send_broadcast.perform
 
         expect(courier).to have_received(:broadcast).
-          with("Europe/Amsterdam", { "content-available": 1 })
+          with(
+            "plus-0000",
+            { "content-available": 1 }
+          ).once
       end
     end
 
@@ -44,22 +56,26 @@ RSpec.describe SendBroadcast do
 
         SendBroadcast.new.perform
 
-        expect(courier).to_not have_received(:broadcast).
-          with("Europe/Amsterdam", { "content-available": 1 })
+        expect(courier).to_not have_received(:broadcast)
       end
     end
 
     it "broadcasts to time zones where it's currently 8:55:00" do
-      now = ActiveSupport::TimeZone.new("Amsterdam").parse("08:55:00")
+      time_zone = ActiveSupport::TimeZone.new("UTC")
+      now = time_zone.parse("08:55:00")
       Timecop.travel(now) do
         courier = instance_double(Courier::Client)
         allow(Courier::Client).to receive(:new).and_return(courier)
         allow(courier).to receive(:broadcast)
 
-        SendBroadcast.new.perform
+        send_broadcast = SendBroadcast.new
+        send_broadcast.perform
 
         expect(courier).to have_received(:broadcast).
-          with("Europe/Amsterdam", { "content-available": 1 })
+          with(
+            "plus-0000",
+            { "content-available": 1 }
+          )
       end
     end
 
@@ -72,8 +88,23 @@ RSpec.describe SendBroadcast do
 
         SendBroadcast.new.perform
 
-        expect(courier).to_not have_received(:broadcast).
-          with("Europe/Amsterdam", { "content-available": 1 })
+        expect(courier).to_not have_received(:broadcast)
+      end
+    end
+
+    describe "#time_zone_identifier" do
+      it "returns a positive time offset as plus-[offset]" do
+        time_zone = ActiveSupport::TimeZone.new("Amsterdam")
+
+        expect(SendBroadcast.new.time_zone_identifier(time_zone)).
+          to start_with("plus-")
+      end
+
+      it "returns a negative time offset as minus-[offset]" do
+        time_zone = ActiveSupport::TimeZone.new("America/Los_Angeles")
+
+        expect(SendBroadcast.new.time_zone_identifier(time_zone)).
+          to start_with("minus-")
       end
     end
   end


### PR DESCRIPTION
This partially fixes the issue where certain time zones will never receive push notifications because the time zone names used by Rails are different from those used by iOS (See thoughtbot/Tropos#185 for more information)

This fixes it by not using the names, but the relative offset from UTC as the channel name. Currently we broadcast to these channels when it's 9am PDT `["america-los_angeles", "america-tijuana", "america-phoenix"]`. 

This PR changes it to broadcast to the channel `minus-0700` instead. This is a more reliable way of identifying time zones across platforms.
